### PR TITLE
Don't require brackets around JIRA issue key

### DIFF
--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -66,7 +66,7 @@ class Issue(ndb.Model):
         Get this issue's title as a HTML fragment, with referenced JIRAs turned into links
         and the non-category / JIRA portion of the title linked to the issue itself.
         """
-        jira_regex = r"\[(SPARK-\d+)\]"
+        jira_regex = r"(SPARK-\d+)"
         tags = re.findall(Issue.TAG_REGEX, self.title)
         title = re.sub(Issue.TAG_REGEX, "", self.title).strip()
         title_html = []


### PR DESCRIPTION
Current matching behavior misses JIRA issue keys in titles that don't have brackets, like in [this issue](https://github.com/apache/spark/pull/2176).
