### PR TITLE
[WIP] Support 'review status' lifecycle / tagging of PRs based on who is blocking on review / updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -215,6 +215,7 @@ def search_open_prs():
             'commenters': [{'username': u, 'data': d} for (u, d) in pr.commenters],
             'last_jenkins_outcome': pr.last_jenkins_outcome,
             'last_jenkins_comment': last_jenkins_comment_dict,
+            'review_status': pr.review_status,
         }
         # Use the first JIRA's information to populate the "Priority" and "Issue Type" columns:
         jiras = pr.parsed_title["jiras"]

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -66,6 +66,7 @@ class Issue(ndb.Model):
     cached_commenters = ndb.PickleProperty()
     cached_last_jenkins_outcome = ndb.StringProperty()
     last_jenkins_comment = ndb.JsonProperty()
+    review_status = ndb.StringProperty(default="Review needed")
 
     ASKED_TO_CLOSE_REGEX = re.compile(r"""
         (mind\s+closing\s+(this|it))|

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -80,3 +80,11 @@ span[data-toggle="popover"]:focus {
 .loading-icon {
     font-size: 36px;
 }
+
+.muted-row {
+    opacity: 0.5;
+}
+
+.muted-row:hover {
+    opacity: 1;
+}

--- a/static/js/views/PRTableView.js
+++ b/static/js/views/PRTableView.js
@@ -81,6 +81,28 @@ define([
       }
     });
 
+    var ReviewStatusCell = React.createClass({displayName: 'ReviewStatusCell',
+      getInitialState: function() {
+        return {value: this.props.pr.review_status};
+      },
+      onChange: function(event) {
+        var newValue = event.target.value;
+        if (newValue !== this.state.value) {
+          console.log("Updating state for PR " + this.props.pr.number + " to '" + newValue + "'");
+          this.props.pr.review_status = newValue;
+          this.setState({value: newValue});
+        }
+      },
+      render: function() {
+          return (
+            React.createElement("select", {className: "form-control", onChange: this.onChange, value: this.state.value}, 
+              React.createElement("option", null, "Review needed"), 
+              React.createElement("option", null, "Update needed")
+            )
+          );
+      }
+    });
+
     var PRTableRow = React.createClass({displayName: 'PRTableRow',
       componentDidMount: function() {
         if (this.refs.jenkinsPopover !== undefined) {
@@ -146,8 +168,9 @@ define([
           React.createElement("td", null, 
             React.createElement(TestWithJenkinsButton, {pr: pr})
           );
+        var rowClass = pr.review_status === "Update needed" ? "muted-row" : "";
         return (
-          React.createElement("tr", null, 
+          React.createElement("tr", {className: rowClass}, 
             React.createElement("td", null, 
               React.createElement("a", {href: pullLink, target: "_blank"}, 
               pr.number
@@ -176,22 +199,15 @@ define([
                 pr.user
               )
             ), 
-            React.createElement("td", null, 
-              commenters
-            ), 
+            React.createElement("td", null, commenters), 
             React.createElement("td", null, 
               React.createElement("span", {className: "lines-added"}, "+", pr.lines_added), 
               React.createElement("span", {className: "lines-deleted"}, "-", pr.lines_deleted)
             ), 
-            React.createElement("td", null, 
-              mergeIcon
-            ), 
-            React.createElement("td", null, 
-              jenkinsCell
-            ), 
-            React.createElement("td", null, 
-              updatedCell
-            ), 
+            React.createElement("td", null, mergeIcon), 
+            React.createElement("td", null, jenkinsCell), 
+            React.createElement("td", null, React.createElement(ReviewStatusCell, {pr: pr})), 
+            React.createElement("td", null, updatedCell), 
             this.props.showJenkinsButtons ? toolsCell : ""
           )
         );
@@ -214,6 +230,7 @@ define([
         'Changes': function(row) { return row.props.pr.lines_changed; },
         'Merges': function(row) { return row.props.pr.is_mergeable; },
         'Jenkins': function(row) { return row.props.pr.last_jenkins_outcome; },
+        'Review Status': function(row) { return "Waiting on author"; },
         'Updated': function(row) { return row.props.pr.updated_at; }
       },
 
@@ -229,6 +246,7 @@ define([
           "Changes",
           "Merges",
           "Jenkins",
+          "Review Status",
           "Updated"
         ];
         if (this.props.showJenkinsButtons) {

--- a/static/jsx/views/PRTableView.jsx
+++ b/static/jsx/views/PRTableView.jsx
@@ -81,6 +81,28 @@ define([
       }
     });
 
+    var ReviewStatusCell = React.createClass({
+      getInitialState: function() {
+        return {value: this.props.pr.review_status};
+      },
+      onChange: function(event) {
+        var newValue = event.target.value;
+        if (newValue !== this.state.value) {
+          console.log("Updating state for PR " + this.props.pr.number + " to '" + newValue + "'");
+          this.props.pr.review_status = newValue;
+          this.setState({value: newValue});
+        }
+      },
+      render: function() {
+          return (
+            <select className="form-control" onChange={this.onChange} value={this.state.value}>
+              <option>Review needed</option>
+              <option>Update needed</option>
+            </select>
+          );
+      }
+    });
+
     var PRTableRow = React.createClass({
       componentDidMount: function() {
         if (this.refs.jenkinsPopover !== undefined) {
@@ -146,8 +168,9 @@ define([
           <td>
             <TestWithJenkinsButton pr={pr}/>
           </td>;
+        var rowClass = pr.review_status === "Update needed" ? "muted-row" : "";
         return (
-          <tr>
+          <tr className={rowClass}>
             <td>
               <a href={pullLink} target="_blank">
               {pr.number}
@@ -176,22 +199,15 @@ define([
                 {pr.user}
               </a>
             </td>
-            <td>
-              {commenters}
-            </td>
+            <td>{commenters}</td>
             <td>
               <span className="lines-added">+{pr.lines_added}</span>
               <span className="lines-deleted">-{pr.lines_deleted}</span>
             </td>
-            <td>
-              {mergeIcon}
-            </td>
-            <td>
-              {jenkinsCell}
-            </td>
-            <td>
-              {updatedCell}
-            </td>
+            <td>{mergeIcon}</td>
+            <td>{jenkinsCell}</td>
+            <td><ReviewStatusCell pr={pr}/></td>
+            <td>{updatedCell}</td>
             {this.props.showJenkinsButtons ? toolsCell : ""}
           </tr>
         );
@@ -214,6 +230,7 @@ define([
         'Changes': function(row) { return row.props.pr.lines_changed; },
         'Merges': function(row) { return row.props.pr.is_mergeable; },
         'Jenkins': function(row) { return row.props.pr.last_jenkins_outcome; },
+        'Review Status': function(row) { return "Waiting on author"; },
         'Updated': function(row) { return row.props.pr.updated_at; }
       },
 
@@ -229,6 +246,7 @@ define([
           "Changes",
           "Merges",
           "Jenkins",
+          "Review Status",
           "Updated"
         ];
         if (this.props.showJenkinsButtons) {


### PR DESCRIPTION
The purpose of this PR is to start a discussion around whether we should implement features for tracking some sort of 'review status' lifecycle for PRs.  My proposal is to extend the UI with features for conveying whether the review process is blocked on further review from reviewers or on an update from the PR's author.  This could be very helpful for rapidly identifying which PRs need more review, since sometimes the most-recent part of the queue will be cluttered up with PRs where I've left a bunch of comments for an author and they take several days to address them.

I was thinking of adding a 'Review Status' column that's viewable by everyone but only editable by users with the proper permissions:

![image](https://cloud.githubusercontent.com/assets/50748/5390252/f465e0d8-80bc-11e4-88c0-45e51f80666d.png)

By default, all PRs start out in the 'Review needed' state.  Once a reviewer feels that the PR is now blocked on the author's update, they may change the status to 'Update needed':

![image](https://cloud.githubusercontent.com/assets/50748/5390256/205ab268-80bd-11e4-9472-4fb6335cadca.png)

When a PR is in the 'Updated needed' state, its row will be slightly transparent (but restored to full opacity on hover):

![image](https://cloud.githubusercontent.com/assets/50748/5390266/4b85c194-80bd-11e4-8b94-793f708135d2.png)

On the backend, we can add some logic for automatically transitioning from 'Update needed' to 'Review needed': if a new commit is added to the PR, its title or description is updated, or the author leaves a comment, then we will automatically mark it as 'Review needed.'

The backend support for this would be helpful in identifying hanging / abandoned PRs.

The screenshots here are just a rough UI mockup that I threw together in a couple of minutes.  I'd love feedback on the overall concept / workflow.  Is this a useful feature?  Should the subdued colors be used on the main page, or only on per-reviewer dashboards?

I also have a couple of React.js-related questions about how to handle data-binding / refresh logic, but I'll discuss those offline.