### PR TITLE
www.github.com -> github.com

### DIFF
--- a/static/js/views/PRTableView.js
+++ b/static/js/views/PRTableView.js
@@ -126,7 +126,7 @@ define([
           React.createElement("i", {className: "glyphicon glyphicon-ok"}) :
           React.createElement("i", {className: "glyphicon glyphicon-remove"}));
 
-        var pullLink = "https://www.github.com/apache/spark/pull/" + pr.number;
+        var pullLink = "https://github.com/apache/spark/pull/" + pr.number;
 
         var jenkinsOutcome = jenkinsOutcomes[pr.last_jenkins_outcome];
         var iconClass = "glyphicon glyphicon-" + jenkinsOutcome.iconName;

--- a/static/jsx/views/PRTableView.jsx
+++ b/static/jsx/views/PRTableView.jsx
@@ -126,7 +126,7 @@ define([
           <i className="glyphicon glyphicon-ok"></i> :
           <i className="glyphicon glyphicon-remove"></i>);
 
-        var pullLink = "https://www.github.com/apache/spark/pull/" + pr.number;
+        var pullLink = "https://github.com/apache/spark/pull/" + pr.number;
 
         var jenkinsOutcome = jenkinsOutcomes[pr.last_jenkins_outcome];
         var iconClass = "glyphicon glyphicon-" + jenkinsOutcome.iconName;


### PR DESCRIPTION
`www.github.com` redirects to `github.com`. The `hub` tool (https://hub.github.com/) doesn't recognize `www.github.com` urls.