### PR TITLE
Add "Refresh" button for updating PR data without reloading page

### DIFF
--- a/static/js/views/AppManager.js
+++ b/static/js/views/AppManager.js
@@ -144,6 +144,12 @@ define([
       componentDidMount: function() {
         this.refreshPrs();
         this.refreshUserInfo();
+        // Refresh every 5 minutes:
+        this.refreshInterval = window.setInterval(this.refreshPrs, 1000 * 60 * 5);
+      },
+
+      componentWillUnmount: function() {
+        window.clearInterval(this.refreshInterval);
       },
 
       render: function() {

--- a/static/js/views/Dashboard.js
+++ b/static/js/views/Dashboard.js
@@ -12,7 +12,7 @@ define([
     var Dashboard = React.createClass({displayName: 'Dashboard',
       mixins: [UrlMixin],
       getInitialState: function() {
-        return {prs: [], activeTab: '', currentPrs: []};
+        return {prs: [], prsByComponent: {}, activeTab: '', currentPrs: []};
       },
 
       componentDidMount: function() {
@@ -26,23 +26,13 @@ define([
       },
 
       componentDidUpdate: function(prevProps, prevState) {
-        if (prevState.activeTab !== this.state.activeTab) {
-          this._filterPrsByComponent(this.state.activeTab);
+        var newActiveTab = this.state.activeTab;
+        if (prevState.activeTab !== newActiveTab || prevState.prs !== this.state.prs) {
+          this.setState({
+            activeTab: newActiveTab,
+            currentPrs: this.state.prsByComponent[newActiveTab] || []
+          });
         }
-      },
-
-      _filterPrsByComponent: function(component) {
-        var neededPrs = [],
-            prs = this.state.prs;
-
-        for (var i = 0; i < prs.length; i++) {
-          if (prs[i].component === component) {
-            neededPrs = prs[i].prs;
-            break;
-          }
-        }
-
-        this.setState({activeTab: component, currentPrs: neededPrs});
       },
 
       _prepareData: function(prs) {
@@ -68,7 +58,11 @@ define([
 
         var tab = this._checkTabAvailability(prsByComponent);
 
-        this.setState({prs: result, activeTab: tab ? tab : mainTab});
+        this.setState({
+          prs: result,
+          activeTab: tab ? tab : mainTab,
+          prsByComponent: prsByComponent
+        });
       },
 
       _checkTabAvailability: function(prsByComponent) {
@@ -88,8 +82,7 @@ define([
           subNavigation = (
             React.createElement(SubNavigation, {
               prs: this.state.prs, 
-              active: this.state.activeTab, 
-              onClick: this._filterPrsByComponent}));
+              active: this.state.activeTab}));
           mainView = (
             React.createElement("div", {className: "container-fluid"}, 
               React.createElement(PRTableView, {

--- a/static/js/views/SubNavigation.js
+++ b/static/js/views/SubNavigation.js
@@ -10,7 +10,6 @@ define([
       onClick: function(event) {
         var component = this.props.component;
         this.pushAnchor(component);
-        this.props.onClick(component);
       },
 
       render: function() {
@@ -29,10 +28,6 @@ define([
         return {prsCountByGroup: []};
       },
 
-      _onClick: function(component) {
-        this.props.onClick(component);
-      },
-
       render: function() {
         var navigationItems = [],
           prs = this.props.prs;
@@ -49,8 +44,7 @@ define([
             key: item.component, 
             component: item.component, 
             label: label, 
-            active: item.component === this.props.active, 
-            onClick: this._onClick}));
+            active: item.component === this.props.active}));
         }
 
         return (

--- a/static/jsx/views/AppManager.jsx
+++ b/static/jsx/views/AppManager.jsx
@@ -144,6 +144,12 @@ define([
       componentDidMount: function() {
         this.refreshPrs();
         this.refreshUserInfo();
+        // Refresh every 5 minutes:
+        this.refreshInterval = window.setInterval(this.refreshPrs, 1000 * 60 * 5);
+      },
+
+      componentWillUnmount: function() {
+        window.clearInterval(this.refreshInterval);
       },
 
       render: function() {

--- a/static/jsx/views/Dashboard.jsx
+++ b/static/jsx/views/Dashboard.jsx
@@ -12,7 +12,7 @@ define([
     var Dashboard = React.createClass({
       mixins: [UrlMixin],
       getInitialState: function() {
-        return {prs: [], activeTab: '', currentPrs: []};
+        return {prs: [], prsByComponent: {}, activeTab: '', currentPrs: []};
       },
 
       componentDidMount: function() {
@@ -26,23 +26,13 @@ define([
       },
 
       componentDidUpdate: function(prevProps, prevState) {
-        if (prevState.activeTab !== this.state.activeTab) {
-          this._filterPrsByComponent(this.state.activeTab);
+        var newActiveTab = this.state.activeTab;
+        if (prevState.activeTab !== newActiveTab || prevState.prs !== this.state.prs) {
+          this.setState({
+            activeTab: newActiveTab,
+            currentPrs: this.state.prsByComponent[newActiveTab] || []
+          });
         }
-      },
-
-      _filterPrsByComponent: function(component) {
-        var neededPrs = [],
-            prs = this.state.prs;
-
-        for (var i = 0; i < prs.length; i++) {
-          if (prs[i].component === component) {
-            neededPrs = prs[i].prs;
-            break;
-          }
-        }
-
-        this.setState({activeTab: component, currentPrs: neededPrs});
       },
 
       _prepareData: function(prs) {
@@ -68,7 +58,11 @@ define([
 
         var tab = this._checkTabAvailability(prsByComponent);
 
-        this.setState({prs: result, activeTab: tab ? tab : mainTab});
+        this.setState({
+          prs: result,
+          activeTab: tab ? tab : mainTab,
+          prsByComponent: prsByComponent
+        });
       },
 
       _checkTabAvailability: function(prsByComponent) {
@@ -88,8 +82,7 @@ define([
           subNavigation = (
             <SubNavigation
               prs={this.state.prs}
-              active={this.state.activeTab}
-              onClick={this._filterPrsByComponent}/>);
+              active={this.state.activeTab}/>);
           mainView = (
             <div className="container-fluid">
               <PRTableView

--- a/static/jsx/views/SubNavigation.jsx
+++ b/static/jsx/views/SubNavigation.jsx
@@ -10,7 +10,6 @@ define([
       onClick: function(event) {
         var component = this.props.component;
         this.pushAnchor(component);
-        this.props.onClick(component);
       },
 
       render: function() {
@@ -29,10 +28,6 @@ define([
         return {prsCountByGroup: []};
       },
 
-      _onClick: function(component) {
-        this.props.onClick(component);
-      },
-
       render: function() {
         var navigationItems = [],
           prs = this.props.prs;
@@ -49,8 +44,7 @@ define([
             key={item.component}
             component={item.component}
             label={label}
-            active={item.component === this.props.active}
-            onClick={this._onClick}/>);
+            active={item.component === this.props.active}/>);
         }
 
         return (


### PR DESCRIPTION
This patch adds a "Refresh" button to the header which reloads the PR data without refreshing the page or navigating away from the current view:

![image](https://cloud.githubusercontent.com/assets/50748/6812162/447dfeca-d22a-11e4-8162-1a65f27cd428.png)

While a refresh is in progress, the button is disabled:

![image](https://cloud.githubusercontent.com/assets/50748/6812181/6038cc80-d22a-11e4-9f86-3aad0cdc4170.png)

Thanks to @tdas for suggesting this feature.