### PR TITLE
[SPARK-6481] Start JIRA issue progress

### DIFF
--- a/sparkprs/jira_api.py
+++ b/sparkprs/jira_api.py
@@ -15,7 +15,7 @@ def get_jira_client():
 def start_issue_progress(issue):
     """
     Given an issue key, e.g. SPARK-6481, mark the issue "In Progress".
-    
+
     This will only happen if the issue's initial state is "Open".
     """
     jira_client = get_jira_client()
@@ -25,16 +25,16 @@ def start_issue_progress(issue):
 
     if status != "Open":
         logging.warn("Could not start progress on JIRA issue {j}. "
-            "It's currently in an '{s}' state. Issues must be in an 'Open' state.".format(
-                j=issue, s=status))
+                     "It's currently in an '{s}' state. Issues must be in an 'Open' state.".format(
+                         j=issue, s=status))
         return
 
     # The Apache Spark user needs the issue assigned to itself in order to change
     # the issue's state.
     jira_client.assign_issue(issue=issue, assignee='apachespark')
-    transition_id = [transition['id'] \
-        for transition in jira_client.transitions(issue) \
-        if transition['name'] == 'Start Progress'][0]
+    transition_id = [transition['id']
+                     for transition in jira_client.transitions(issue)
+                     if transition['name'] == 'Start Progress'][0]
     # Passing transition by name doesn't work, though it should according to the docs...
     jira_client.transition_issue(issue=issue, transition=transition_id)
 

--- a/sparkprs/jira_api.py
+++ b/sparkprs/jira_api.py
@@ -23,24 +23,27 @@ def start_issue_progress(issue):
     status = issue_info.fields.status.name
     assignee = issue_info.fields.assignee.name if issue_info.fields.assignee else None
 
-    if status != "Open":
+    if status == "In Progress":
+        return
+    elif status != "Open":
         logging.warn("Could not start progress on JIRA issue {j}. "
                      "It's currently in an '{s}' state. Issues must be in an 'Open' state.".format(
                          j=issue, s=status))
         return
 
-    # The Apache Spark user needs the issue assigned to itself in order to change
-    # the issue's state.
-    jira_client.assign_issue(issue=issue, assignee='apachespark')
-    transition_id = [transition['id']
-                     for transition in jira_client.transitions(issue)
-                     if transition['name'] == 'Start Progress'][0]
-    # Passing transition by name doesn't work, though it should according to the docs...
-    jira_client.transition_issue(issue=issue, transition=transition_id)
-
-    # Restore the original assignee.
-    jira_client.assign_issue(issue=issue, assignee=assignee)
-    logging.info("Started progress on JIRA issue {j}.".format(j=issue))
+    try:
+        # The PR dashboard user needs the issue assigned to itself in order to change
+        # the issue's state.
+        jira_client.assign_issue(issue=issue, assignee=app.config['JIRA_USERNAME'])
+        transition_id = [transition['id']
+                         for transition in jira_client.transitions(issue)
+                         if transition['name'] == 'Start Progress'][0]
+        # Passing transition by name doesn't work, though it should according to the docs...
+        jira_client.transition_issue(issue=issue, transitionId=transition_id)
+        logging.info("Started progress on JIRA issue {j}.".format(j=issue))
+    finally:
+        # Restore the original assignee.
+        jira_client.assign_issue(issue=issue, assignee=assignee)
 
 
 def link_issue_to_pr(issue, pr):

--- a/sparkprs/jira_api.py
+++ b/sparkprs/jira_api.py
@@ -12,6 +12,37 @@ def get_jira_client():
                                         app.config['JIRA_PASSWORD']))
 
 
+def start_issue_progress(issue):
+    """
+    Given an issue key, e.g. SPARK-6481, mark the issue "In Progress".
+    
+    This will only happen if the issue's initial state is "Open".
+    """
+    jira_client = get_jira_client()
+    issue_info = jira_client.issue(issue)
+    status = issue_info.fields.status.name
+    assignee = issue_info.fields.assignee.name if issue_info.fields.assignee else None
+
+    if status != "Open":
+        logging.warn("Could not start progress on JIRA issue {j}. "
+            "It's currently in an '{s}' state. Issues must be in an 'Open' state.".format(
+                j=issue, s=status))
+        return
+
+    # The Apache Spark user needs the issue assigned to itself in order to change
+    # the issue's state.
+    jira_client.assign_issue(issue=issue, assignee='apachespark')
+    transition_id = [transition['id'] \
+        for transition in jira_client.transitions(issue) \
+        if transition['name'] == 'Start Progress'][0]
+    # Passing transition by name doesn't work, though it should according to the docs...
+    jira_client.transition_issue(issue=issue, transition=transition_id)
+
+    # Restore the original assignee.
+    jira_client.assign_issue(issue=issue, assignee=assignee)
+    logging.info("Started progress on JIRA issue {j}.".format(j=issue))
+
+
 def link_issue_to_pr(issue, pr):
     """
     Create a link in JIRA to a pull request and add a comment linking to the PR.

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -9,7 +9,7 @@ import logging
 import re
 from sparkprs import app
 from sparkprs.utils import parse_pr_title, is_jenkins_command, contains_jenkins_command
-from sparkprs.jira_api import link_issue_to_pr
+from sparkprs.jira_api import start_issue_progress, link_issue_to_pr
 
 
 class KVS(ndb.Model):
@@ -254,6 +254,10 @@ class Issue(ndb.Model):
                 link_issue_to_pr("SPARK-%s" % issue_number, self)
             except:
                 logging.exception("Exception when linking to JIRA issue SPARK-%s" % issue_number)
+            try:
+                start_issue_progress("SPARK-%s" % issue_number)
+            except:
+                logging.exception("Exception when starting progress on JIRA issue SPARK-%s" % issue_number)
 
         self.put()  # Write our modifications back to the database
 

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -257,7 +257,8 @@ class Issue(ndb.Model):
             try:
                 start_issue_progress("SPARK-%s" % issue_number)
             except:
-                logging.exception("Exception when starting progress on JIRA issue SPARK-%s" % issue_number)
+                logging.exception(
+                    "Exception when starting progress on JIRA issue SPARK-%s" % issue_number)
 
         self.put()  # Write our modifications back to the database
 


### PR DESCRIPTION
This patch lets the dashboard mark a JIRA as in progress when a PR against it is opened.