### PR TITLE
Bump JS, CSS, and Node dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ## Spark PR Review Board
 
 [![Build Status](https://travis-ci.org/databricks/spark-pr-dashboard.svg?branch=master)](https://travis-ci.org/databricks/spark-pr-dashboard)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
+
 ## Spark PR Review Board
 
 [![Build Status](https://travis-ci.org/databricks/spark-pr-dashboard.svg?branch=master)](https://travis-ci.org/databricks/spark-pr-dashboard)
+[![devDependency
+Status](https://david-dm.org/databricks/spark-pr-dashboard/dev-status.svg)](https://david-dm.org/databricks/spark-pr-dashboard#info=devDependencies)
 
 This repository hosts the code for [spark-prs.appspot.com](http://spark-prs.appspot.com), a tool for assisting in [Apache Spark](https://github.com/apache/spark/) pull request review.
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jsxcs": "git://github.com/brix/grunt-jsxcs#9125b31785b8a13161c98d73bf4b6aa658eea1c1",
-    "grunt-jsxhint": "^0.4.0",
-    "grunt-react": "^0.10.0",
-    "react-tools": "^0.12.1"
+    "grunt-jsxcs": "git://github.com/brix/grunt-jsxcs.git#9125b31785b8a13161c98d73bf4b6aa658eea1c1",
+    "grunt-jsxhint": "^0.6.0",
+    "grunt-react": "^0.12.2",
+    "react-tools": "^0.13.3"
   }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,12 +1,12 @@
 require.config({
   baseUrl: "/static/js/",
   paths: {
-    "jquery": "//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min",
-    "underscore": "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min",
-    "bootstrap": "//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min",
+    "jquery": "//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min",
+    "underscore": "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min",
+    "bootstrap": "//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min",
     "marked": "//cdnjs.cloudflare.com/ajax/libs/marked/0.3.2/marked.min",
-    "jquery-timeago": "//cdnjs.cloudflare.com/ajax/libs/jquery-timeago/1.4.0/jquery.timeago.min",
-    "react": "//cdnjs.cloudflare.com/ajax/libs/react/0.12.0/react",
+    "jquery-timeago": "//cdnjs.cloudflare.com/ajax/libs/jquery-timeago/1.4.1/jquery.timeago.min",
+    "react": "//cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react",
     "react-mini-router": "libs/react-mini-router"
   },
   shim: {

--- a/static/js/views/AppManager.js
+++ b/static/js/views/AppManager.js
@@ -12,7 +12,7 @@ define([
 
     var RouterMixin = Router.RouterMixin;
 
-    var NavigationHeader = React.createClass({displayName: 'NavigationHeader',
+    var NavigationHeader = React.createClass({displayName: "NavigationHeader",
       render: function() {
         return (
           React.createElement("div", {className: "navbar-header"}, 
@@ -24,7 +24,7 @@ define([
       }
     });
 
-    var GitHubUser = React.createClass({displayName: 'GitHubUser',
+    var GitHubUser = React.createClass({displayName: "GitHubUser",
       render: function() {
         var link = "/users/" + this.props.username;
         return (
@@ -36,7 +36,7 @@ define([
       }
     });
 
-    var GitHubLogin = React.createClass({displayName: 'GitHubLogin',
+    var GitHubLogin = React.createClass({displayName: "GitHubLogin",
       render: function() {
         return (
           React.createElement("a", {href: "/login", className: "btn btn-default navbar-btn"}, 
@@ -46,7 +46,7 @@ define([
       }
     });
 
-    var GitHubLogout = React.createClass({displayName: 'GitHubLogout',
+    var GitHubLogout = React.createClass({displayName: "GitHubLogout",
       render: function() {
         return (
           React.createElement("a", {href: "/logout", className: "btn btn-default navbar-btn"}, 
@@ -56,7 +56,7 @@ define([
       }
     });
 
-    var RefreshButton = React.createClass({displayName: 'RefreshButton',
+    var RefreshButton = React.createClass({displayName: "RefreshButton",
       render: function() {
         return (
           React.createElement("a", {className: "btn btn-default navbar-btn", 
@@ -69,7 +69,7 @@ define([
       }
     });
 
-    var AppManager = React.createClass({displayName: 'AppManager',
+    var AppManager = React.createClass({displayName: "AppManager",
       mixins: [RouterMixin],
 
       routes: {

--- a/static/js/views/Dashboard.js
+++ b/static/js/views/Dashboard.js
@@ -9,7 +9,7 @@ define([
   function(React, $, _, SubNavigation, PRTableView, UrlMixin) {
     "use strict";
 
-    var Dashboard = React.createClass({displayName: 'Dashboard',
+    var Dashboard = React.createClass({displayName: "Dashboard",
       mixins: [UrlMixin],
       getInitialState: function() {
         return {prs: [], prsByComponent: {}, activeTab: '', currentPrs: []};

--- a/static/js/views/PRTableView.js
+++ b/static/js/views/PRTableView.js
@@ -21,7 +21,7 @@ define([
       Unknown: {label: "Unknown", iconName: "question-sign"}
     };
 
-    var JIRALink = React.createClass({displayName: 'JIRALink',
+    var JIRALink = React.createClass({displayName: "JIRALink",
       render: function() {
         var link = "http://issues.apache.org/jira/browse/SPARK-" + this.props.number;
         return (
@@ -32,7 +32,7 @@ define([
       }
     });
 
-    var Commenter = React.createClass({displayName: 'Commenter',
+    var Commenter = React.createClass({displayName: "Commenter",
       componentDidMount: function() {
         var _this = this;
         $(this.refs.commenter.getDOMNode()).popover({
@@ -80,7 +80,7 @@ define([
       }
     });
 
-    var TestWithJenkinsButton = React.createClass({displayName: 'TestWithJenkinsButton',
+    var TestWithJenkinsButton = React.createClass({displayName: "TestWithJenkinsButton",
       onClick: function() {
         var prNum = this.props.pr.number;
         var shouldTest = confirm("Are you sure you want to test PR " + prNum + " with Jenkins?");
@@ -100,7 +100,7 @@ define([
       }
     });
 
-    var PRTableRow = React.createClass({displayName: 'PRTableRow',
+    var PRTableRow = React.createClass({displayName: "PRTableRow",
       componentDidMount: function() {
         if (this.refs.jenkinsPopover !== undefined) {
           $(this.refs.jenkinsPopover.getDOMNode()).popover();
@@ -142,9 +142,9 @@ define([
 
           jenkinsCell = (
             React.createElement("span", {ref: "jenkinsPopover", tabIndex: "0", 
-              'data-toggle': "popover", 'data-trigger': "focus", 
-              'data-placement': "left", 'data-html': "true", 
-              'data-title': title, 'data-content': content}, 
+              "data-toggle": "popover", "data-trigger": "focus", 
+              "data-placement": "left", "data-html": "true", 
+              "data-title": title, "data-content": content}, 
               React.createElement("i", {className: iconClass}), 
               React.createElement("span", {className: "jenkins-outcome-link"}, 
                 jenkinsOutcome.label
@@ -218,7 +218,7 @@ define([
       }
     });
 
-    var PRTableView = React.createClass({displayName: 'PRTableView',
+    var PRTableView = React.createClass({displayName: "PRTableView",
       propTypes: {
         prs: React.PropTypes.array.isRequired
       },

--- a/static/js/views/SubNavigation.js
+++ b/static/js/views/SubNavigation.js
@@ -5,7 +5,7 @@ define([
   function(React, UrlMixin) {
     "use strict";
 
-    var SubNavigationItem = React.createClass({displayName: 'SubNavigationItem',
+    var SubNavigationItem = React.createClass({displayName: "SubNavigationItem",
       mixins: [UrlMixin],
       onClick: function(event) {
         var component = this.props.component;
@@ -23,7 +23,7 @@ define([
       }
     });
 
-    var SubNavigation = React.createClass({displayName: 'SubNavigation',
+    var SubNavigation = React.createClass({displayName: "SubNavigation",
       getDefaultProps: function() {
         return {prsCountByGroup: []};
       },

--- a/static/js/views/TableView.js
+++ b/static/js/views/TableView.js
@@ -6,7 +6,7 @@ define([
   function(React, $, _) {
     "use strict";
 
-    var ColumnHeader = React.createClass({displayName: 'ColumnHeader',
+    var ColumnHeader = React.createClass({displayName: "ColumnHeader",
       propTypes: {
         name: React.PropTypes.string.isRequired,
         sortable: React.PropTypes.bool.isRequired,
@@ -43,7 +43,7 @@ define([
     /**
      * A table view that supports customizable per-column sorting.
      */
-    var TableView = React.createClass({displayName: 'TableView',
+    var TableView = React.createClass({displayName: "TableView",
       propTypes: {
         rows: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
         columnNames: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,

--- a/static/js/views/UserDashboard.js
+++ b/static/js/views/UserDashboard.js
@@ -7,7 +7,7 @@ define([
   function(React, $, _, PRTableView) {
     "use strict";
 
-    var UserDashboard = React.createClass({displayName: 'UserDashboard',
+    var UserDashboard = React.createClass({displayName: "UserDashboard",
       getInitialState: function() {
         return {prsAuthored: [], prsCommentedOn: []};
       },

--- a/static/js/views/UsersPage.js
+++ b/static/js/views/UsersPage.js
@@ -7,7 +7,7 @@ define([
   function(React, $, _, TableView) {
     'use strict';
 
-    var UsersTableRow = React.createClass({displayName: 'UsersTableRow',
+    var UsersTableRow = React.createClass({displayName: "UsersTableRow",
       render: function() {
         var href = '/users/' + this.props.username;
         return (
@@ -19,7 +19,7 @@ define([
       }
     });
 
-    var UsersPage = React.createClass({displayName: 'UsersPage',
+    var UsersPage = React.createClass({displayName: "UsersPage",
 
       columnNames: ['Username', 'Open PRs'],
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,8 @@
 <html>
 <head>
     <title>{% block title %}Spark Pull Requests{% endblock %}</title>
-    <link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
-    <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/octicons/2.0.2/octicons.min.css">
+    <link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/octicons/2.4.1/octicons.min.css">
     <link rel="stylesheet" type="text/css" href="/static/css/main.css?version={{APP_VERSION}}">
 </head>
 
@@ -11,7 +11,7 @@
 {% block content %}
 {% endblock %}
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.14/require.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.18/require.min.js"></script>
 <script type="text/javascript" src="/static/js/main.js?version={{APP_VERSION}}"></script>
 {% block extrajs %}
 {% endblock %}


### PR DESCRIPTION
This PR bumps JS + CSS + Node dependencies. I also committed rebuilt JS, since the newer versions of the React node plugins generate code which contains double quotes instead of single quotes.

I've opened this PR so that changes caused by the toolchain upgrade don't pollute the diff for another patch that I'm going to submit soon.