### PR TITLE
complete regex for mllib

### DIFF
--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -82,7 +82,7 @@ class Issue(ndb.Model):
         ("Docs", "docs", "docs|README"),
         ("EC2", "ec2", "ec2"),
         ("SQL", "sql", "sql"),
-        ("MLlib", "mllib", "mllib"),
+        ("MLlib", "mllib|ml", "mllib|/ml/|docs/ml"),
         ("GraphX", "graphx|pregel", "graphx"),
         ("Streaming", "stream|flume|kafka|twitter|zeromq", "streaming"),
         ("R", "SparkR", "(^r/)|src/main/r/|api/r/"),

--- a/sparkprs/utils.py
+++ b/sparkprs/utils.py
@@ -83,7 +83,7 @@ def parse_pr_title(pr_title):
     # Remove JIRAs from the metadata:
     metadata_without_jiras = re.sub(r"\[?SPARK-\d+\]?", "", metadata, flags=re.I)
     # Remove certain tags, since they're generally noise once the PRs are categorized:
-    tags_to_remove = ["MLLIB", "CORE", "PYSPARK", "SQL", "STREAMING", "YARN", "GRAPHX"]
+    tags_to_remove = ["MLLIB", "ML", "CORE", "PYSPARK", "SQL", "STREAMING", "YARN", "GRAPHX"]
     tags_to_remove_regex = "|".join(r"(?:\[?" + x + "\]?)" for x in tags_to_remove)
     metadata_without_jiras_or_tags = \
         re.sub(tags_to_remove_regex, "", metadata_without_jiras, flags=re.I).strip()


### PR DESCRIPTION
The current regex is not sufficient for MLlib. This PR adds the following:

* `/ml/` to match `pyspark/ml/` and `examples/ml/`.
* `docs/ml` to match `docs/ml-*.md`

Also removes `[ML]` from PR title.

@JoshRosen 