### PR TITLE
Fix backfilling / bulk-loading of old PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Initially, the dashboard will be empty because the development appserver doesn't
 
 If you'd rather generate your own datastore, configure `settings.cfg` with proper GitHub API keys, then browse to [http://localhost:8000/cron](http://localhost:8000/cron) and hit "Run now" to manually trigger the cron job that refreshes pull requests.
 
+In order to backfill the datastore with old pull requests, visit `/tasks/github/backfill-prs` and log in with AppEngine app admin credentials. This will enqueue update tasks for every pull request ever opened against the repository, using the slower `old-prs` task queue to avoid exceeding the GitHub API rate limit.
+
 ### Front-end development
 
 The front-end UI is implemented as a single-page web app using the [React.js](https://facebook.github.io/react/) library.  The majority of UI components are written in React's [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html) Javascript dialect; these files have `.jsx` extensions.  These JSX files are converted into plain Javascript using a [Grunt](http://gruntjs.com/) task.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ LinkHeader==0.4.2
 requests==2.5.0
 jira==0.16
 feedparser==5.1.3
+more-itertools==2.2


### PR DESCRIPTION
This patch fixes a bug that broke the ability to rebuild / backfill the PR dashboard's database.

Previously, deleting the `issues_since` key was sufficient to cause old PRs to be re-fetched and updated. On repositories with huge numbers of pull requests, however, a refresh task might not be able to update the `issues_since` key by the time that the next refresh task starts. Or, even worse, the `issues_since` task might _never_ get updated due to timeouts in the update task. In these situations, every cron job run of the update task might enqueue thousands of pull request update tasks, causing the `fresh-prs` task queue to grow at a rate which caused us to rapidly exceed our GitHub API rate limit, bringing the entire update process to a grinding halt.

The fix for this, implemented here, is to no longer rely on `/tasks/github/update-prs` for bulk-loading of old pull requests. The `/tasks/github/update-prs` task will now immediately set `issues_since` to the current time if it is not set, preventing the `fresh-prs` queue explosion problem. To address bulk-loading, I added a new `/tasks/github/backfill-prs` which enqueues update tasks for every pull request ever opened against the repository, using the slower `old-prs` task queue to avoid exceeding the GitHub API rate limit.