### PR TITLE
Add JIRA target versions column

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.5.0
 jira==0.16
 feedparser==5.1.3
 more-itertools==2.2
+natsort==4.0.4

--- a/sparkprs/controllers/prs.py
+++ b/sparkprs/controllers/prs.py
@@ -49,6 +49,7 @@ def search_open_prs():
                 d['jira_issuetype_name'] = first_jira.issuetype_name
                 d['jira_issuetype_icon_url'] = first_jira.issuetype_icon_url
                 d['jira_shepherd_display_name'] = first_jira.shepherd_display_name
+                d['jira_target_versions'] = first_jira.target_versions
         json_dicts.append(d)
     response = Response(json.dumps(json_dicts), mimetype='application/json')
     return response

--- a/sparkprs/controllers/prs.py
+++ b/sparkprs/controllers/prs.py
@@ -58,7 +58,7 @@ def search_open_prs():
                 if jira:
                     target_versions.update(jira.target_versions)
             if target_versions:
-                d['jira_target_versions'] = natsorted(target_versions, reverse=True)
+                d['jira_target_versions'] = natsorted(target_versions)
         json_dicts.append(d)
     response = Response(json.dumps(json_dicts), mimetype='application/json')
     return response

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -3,7 +3,6 @@ from google.appengine.api import urlfetch
 from collections import defaultdict
 import json
 import logging
-from natsort import natsorted
 import re
 from sparkprs import app
 from sparkprs.utils import parse_pr_title, is_jenkins_command, compute_last_jenkins_outcome
@@ -246,7 +245,9 @@ class JIRAIssue(ndb.Model):
     def target_versions(self):
         versions = self.issue_json["fields"]['customfield_12310320']
         if versions:
-            return natsorted([v['name'] for v in versions], reverse=True)
+            return [v['name'] for v in versions]
+        else:
+            return []
 
     @classmethod
     def get_or_create(cls, issue_id):

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -244,7 +244,6 @@ class JIRAIssue(ndb.Model):
 
     @property
     def target_versions(self):
-        print self.issue_json["fields"]['customfield_12310320']
         versions = self.issue_json["fields"]['customfield_12310320']
         if versions:
             return natsorted([v['name'] for v in versions], reverse=True)

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -3,6 +3,7 @@ from google.appengine.api import urlfetch
 from collections import defaultdict
 import json
 import logging
+from natsort import natsorted
 import re
 from sparkprs import app
 from sparkprs.utils import parse_pr_title, is_jenkins_command, compute_last_jenkins_outcome
@@ -240,6 +241,13 @@ class JIRAIssue(ndb.Model):
         shepherd = self.issue_json["fields"]['customfield_12311620']
         if shepherd:
             return shepherd['displayName']
+
+    @property
+    def target_versions(self):
+        print self.issue_json["fields"]['customfield_12310320']
+        versions = self.issue_json["fields"]['customfield_12310320']
+        if versions:
+            return natsorted([v['name'] for v in versions], reverse=True)
 
     @classmethod
     def get_or_create(cls, issue_id):

--- a/static/js/views/PRTableView.js
+++ b/static/js/views/PRTableView.js
@@ -120,6 +120,11 @@ define([
         });
         var jiraLinks = React.createElement("ul", {className: "jira-links-list"}, jiraLinkRows);
 
+        var targetVersionRows =  _.map(pr.jira_target_versions, function(version) {
+          return (React.createElement("li", null, version));
+        });
+        var targetVersions = React.createElement("ul", {className: "jira-links-list"}, targetVersionRows);
+
         var commenters = _.map(pr.commenters, function(comment) {
           return (
             React.createElement(Commenter, {
@@ -195,6 +200,9 @@ define([
                 alt: pr.jira_issuetype_name})
             ), 
             React.createElement("td", null, 
+              targetVersions
+            ), 
+            React.createElement("td", null, 
               React.createElement("a", {href: pullLink, target: "_blank"}, 
                 pr.parsed_title.metadata + pr.parsed_title.title
               )
@@ -239,6 +247,7 @@ define([
         'JIRAs': function(row) { return row.props.pr.parsed_title.jiras; },
         'Priority': function(row) { return row.props.pr.jira_priority_name; },
         'Issue Type': function(row) { return row.props.pr.jira_issuetype_name; },
+        'Target Versions': function(row) { return row.props.pr.jira_target_versions || ''; },
         'Title': function(row) { return row.props.pr.parsed_title.title.toLowerCase(); },
         'Author': function(row) { return row.props.pr.user.toLowerCase(); },
         'Shepherd': function(row) { return row.props.pr.jira_shepherd_display_name || ''; },
@@ -255,6 +264,7 @@ define([
           "JIRAs",
           "Priority",
           "Issue Type",
+          "Target Versions",
           "Title",
           "Author",
           "Shepherd",

--- a/static/js/views/PRTableView.js
+++ b/static/js/views/PRTableView.js
@@ -247,7 +247,7 @@ define([
         'JIRAs': function(row) { return row.props.pr.parsed_title.jiras; },
         'Priority': function(row) { return row.props.pr.jira_priority_name; },
         'Issue Type': function(row) { return row.props.pr.jira_issuetype_name; },
-        'Target Versions': function(row) { return row.props.pr.jira_target_versions || ''; },
+        'Target Versions': function(row) { return row.props.pr.jira_target_versions || 'A'; },
         'Title': function(row) { return row.props.pr.parsed_title.title.toLowerCase(); },
         'Author': function(row) { return row.props.pr.user.toLowerCase(); },
         'Shepherd': function(row) { return row.props.pr.jira_shepherd_display_name || ''; },

--- a/static/jsx/views/PRTableView.jsx
+++ b/static/jsx/views/PRTableView.jsx
@@ -247,7 +247,7 @@ define([
         'JIRAs': function(row) { return row.props.pr.parsed_title.jiras; },
         'Priority': function(row) { return row.props.pr.jira_priority_name; },
         'Issue Type': function(row) { return row.props.pr.jira_issuetype_name; },
-        'Target Versions': function(row) { return row.props.pr.jira_target_versions || ''; },
+        'Target Versions': function(row) { return row.props.pr.jira_target_versions || 'A'; },
         'Title': function(row) { return row.props.pr.parsed_title.title.toLowerCase(); },
         'Author': function(row) { return row.props.pr.user.toLowerCase(); },
         'Shepherd': function(row) { return row.props.pr.jira_shepherd_display_name || ''; },

--- a/static/jsx/views/PRTableView.jsx
+++ b/static/jsx/views/PRTableView.jsx
@@ -120,6 +120,11 @@ define([
         });
         var jiraLinks = <ul className="jira-links-list">{jiraLinkRows}</ul>;
 
+        var targetVersionRows =  _.map(pr.jira_target_versions, function(version) {
+          return (<li>{version}</li>);
+        });
+        var targetVersions = <ul className="jira-links-list">{targetVersionRows}</ul>;
+
         var commenters = _.map(pr.commenters, function(comment) {
           return (
             <Commenter
@@ -195,6 +200,9 @@ define([
                 alt={pr.jira_issuetype_name}/>
             </td>
             <td>
+              {targetVersions}
+            </td>
+            <td>
               <a href={pullLink} target="_blank">
                 {pr.parsed_title.metadata + pr.parsed_title.title}
               </a>
@@ -239,6 +247,7 @@ define([
         'JIRAs': function(row) { return row.props.pr.parsed_title.jiras; },
         'Priority': function(row) { return row.props.pr.jira_priority_name; },
         'Issue Type': function(row) { return row.props.pr.jira_issuetype_name; },
+        'Target Versions': function(row) { return row.props.pr.jira_target_versions || ''; },
         'Title': function(row) { return row.props.pr.parsed_title.title.toLowerCase(); },
         'Author': function(row) { return row.props.pr.user.toLowerCase(); },
         'Shepherd': function(row) { return row.props.pr.jira_shepherd_display_name || ''; },
@@ -255,6 +264,7 @@ define([
           "JIRAs",
           "Priority",
           "Issue Type",
+          "Target Versions",
           "Title",
           "Author",
           "Shepherd",


### PR DESCRIPTION
This patch adds a new column which displays JIRA target versions.

### Behaviors

- If a pull request has multiple linked JIRA issues, the displayed target versions are the union of the individual JIRA issues' target versions.
- If there are multiple target versions for a pull request, they are displayed in ascending order, with the earliest target version displayed first.
- The target versions column is sorted from oldest to newest version, with untargeted PRs appearing after PRs targeted at the latest version.

### Screenshots

**Top of sorted list:**

![image](https://cloud.githubusercontent.com/assets/50748/11830260/11261012-a358-11e5-98c4-db150ed10fd3.png)

**Bottom of sorted list:**

![image](https://cloud.githubusercontent.com/assets/50748/11830263/194ba7d4-a358-11e5-9efb-276195bee4ce.png)
