### PR TITLE
Allow JIRA bot to start progress on reopened issues

### DIFF
--- a/sparkprs/jira_api.py
+++ b/sparkprs/jira_api.py
@@ -27,8 +27,8 @@ def start_issue_progress(issue):
         return
     elif status not in ("Open", "Reopened"):
         logging.warn(("Could not start progress on JIRA issue {j}. "
-                     "It's currently in an '{s}' state. "
-                     "Issues must be in an 'Open' or 'Reopened' state.").format(j=issue, s=status))
+                      "It's currently in an '{s}' state. "
+                      "Issues must be in an 'Open' or 'Reopened' state.").format(j=issue, s=status))
         return
 
     try:

--- a/sparkprs/jira_api.py
+++ b/sparkprs/jira_api.py
@@ -2,11 +2,17 @@
 Functions for integrating with JIRA.
 """
 import logging
+
+from google.appengine.api import urlfetch
 import jira.client
+
 from sparkprs import app
 
 
 def get_jira_client():
+    # Bump up the default fetch deadline.
+    # This setting is thread-specific, which is why we set it here.
+    urlfetch.set_default_fetch_deadline(60)
     return jira.client.JIRA({'server': app.config['JIRA_API_BASE']},
                             basic_auth=(app.config['JIRA_USERNAME'],
                                         app.config['JIRA_PASSWORD']))

--- a/sparkprs/jira_api.py
+++ b/sparkprs/jira_api.py
@@ -16,7 +16,7 @@ def start_issue_progress(issue):
     """
     Given an issue key, e.g. SPARK-6481, mark the issue "In Progress".
 
-    This will only happen if the issue's initial state is "Open".
+    This will only happen if the issue's initial state is "Open" or "Reopened".
     """
     jira_client = get_jira_client()
     issue_info = jira_client.issue(issue)
@@ -25,10 +25,10 @@ def start_issue_progress(issue):
 
     if status == "In Progress":
         return
-    elif status != "Open":
-        logging.warn("Could not start progress on JIRA issue {j}. "
-                     "It's currently in an '{s}' state. Issues must be in an 'Open' state.".format(
-                         j=issue, s=status))
+    elif status not in ("Open", "Reopened"):
+        logging.warn(("Could not start progress on JIRA issue {j}. "
+                     "It's currently in an '{s}' state. "
+                     "Issues must be in an 'Open' or 'Reopened' state.").format(j=issue, s=status))
         return
 
     try:


### PR DESCRIPTION
The JIRA bot should be able to start progress on reopened issues, not just open ones. This was causing the PR updates for SPARK-529 to fail. I also increased the `urlfetch` request timeout in the JIRA handlers since a slow Apache JIRA was causing tasks to fail.