### PR TITLE
Switched from grunt-jsxcs to grunt-jscs

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,4 +1,6 @@
 {
+  "esprima" : "esprima-fb",
+
   "requireCurlyBraces": [
     "if",
     "else",
@@ -97,7 +99,7 @@
 
   "requireCapitalizedConstructors": true,
 
-  "validateJSDoc": {
+  "jsDoc": {
     "checkParamNames": true,
     "checkRedundantParams": true
   }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,7 +41,6 @@ module.exports = function(grunt) {
 
   // Code quality tool for jsx and js (safe to replace JSHint)
   grunt.loadNpmTasks("grunt-jsxhint");
-  // Use the JSX code style checker, since it is aware of both .js and jsx files
   grunt.loadNpmTasks("grunt-jscs");
 
   grunt.loadNpmTasks('grunt-contrib-watch');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function(grunt) {
   // Code quality tool for jsx and js (safe to replace JSHint)
   grunt.loadNpmTasks("grunt-jsxhint");
   // Use the JSX code style checker, since it is aware of both .js and jsx files
-  grunt.loadNpmTasks("grunt-jsxcs");
+  grunt.loadNpmTasks("grunt-jscs");
 
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-react');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jsxcs": "git://github.com/brix/grunt-jsxcs.git#9125b31785b8a13161c98d73bf4b6aa658eea1c1",
+    "grunt-jscs": "^2.8.0",
     "grunt-jsxhint": "^0.6.0",
     "grunt-react": "^0.12.2",
     "react-tools": "^0.13.3"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "grunt-jscs": "^2.8.0",
     "grunt-jsxhint": "^0.6.0",
     "grunt-react": "^0.12.2",
-    "react-tools": "^0.13.3"
+    "react-tools": "^0.13.3",
+    "esprima": "^2.7.2",
+    "esprima-fb": "^15001.1001.0-dev-harmony-fb"
   }
 }


### PR DESCRIPTION
Switched from grunt-jsxcs to grunt-jscs since the former has been deleted and the latter now supports jsx files. This fixes #69 