### PR TITLE
Added a dashboard for tracking stale PRs

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ app.register_blueprint(admin, url_prefix='/admin')
 
 @app.route('/')
 @app.route('/open-prs')
+@app.route('/stale-prs')
 @app.route('/users')
 @app.route('/users/<username>')
 def main(username=None):

--- a/settings.cfg.template
+++ b/settings.cfg.template
@@ -23,6 +23,9 @@ GITHUB_PROJECT='apache/spark'
 # processing rate.
 FRESHNESS_THRESHOLD = 60 * 60 * 24
 
+# The number of days a PR must have last been updated to be considered stale
+DAYS_STALE = 30
+
 # Key used to sign cookies; generate one randomly using os.urandom(24)
 SECRET_KEY = ''
 

--- a/sparkprs/controllers/prs.py
+++ b/sparkprs/controllers/prs.py
@@ -20,6 +20,7 @@ def search_open_prs():
     prs = Issue.query(Issue.state == "open").order(-Issue.updated_at).fetch()
     return search_prs(prs)
 
+
 @prs.route('/search-stale-prs')
 @cache.cached(timeout=60)
 def search_stale_prs():
@@ -27,6 +28,7 @@ def search_stale_prs():
                          Issue.updated_at < datetime.datetime.today() - datetime.timedelta(days=30))
     stalePrs = Issue.query(issueQuery).order(-Issue.updated_at).fetch()
     return search_prs(stalePrs)
+
 
 def search_prs(prs):
     json_dicts = []

--- a/static/js/mixins/UrlMixin.js
+++ b/static/js/mixins/UrlMixin.js
@@ -10,8 +10,11 @@ define([
         return component.replace(/ /g,'').toLowerCase();
       },
 
-      pushAnchor: function(component) {
+      pushAnchor: function(component, staleOpt) {
         var anchor = this.getAnchor(component);
+        if (typeof staleOpt !== 'undefined') {
+          anchor = this.getAnchor(staleOpt) + '&' + anchor;
+        }
         window.location.hash = anchor;
       }
     };

--- a/static/js/views/AppManager.js
+++ b/static/js/views/AppManager.js
@@ -4,10 +4,11 @@ define([
     'jquery',
     'underscore',
     'views/Dashboard',
+    'views/StaleDashboard',
     'views/UsersPage',
     'views/UserDashboard'
   ],
-  function(React, Router, $, _, Dashboard, UsersPage, UserDashboard) {
+  function(React, Router, $, _, Dashboard, StaleDashboard, UsersPage, UserDashboard) {
     "use strict";
 
     var RouterMixin = Router.RouterMixin;
@@ -98,8 +99,8 @@ define([
 
       staleOpenPrs: function() {
         return (
-          React.createElement(Dashboard, {
-            prs: this.state.stalePrs,
+          React.createElement(StaleDashboard, {
+            prs: this.state.stalePrs, 
             showJenkinsButtons: this.userCanUseJenkins()})
           );
       },
@@ -135,6 +136,7 @@ define([
             _this.setState({refreshInProgress: false});
           }
         });
+        this.refreshStalePrs();
       },
 
       refreshStalePrs: function() {
@@ -154,11 +156,6 @@ define([
         });
       },
 
-      refreshAllPrs: function() {
-        this.refreshPrs()
-        this.refreshStalePrs()
-      },
-
       refreshUserInfo: function() {
         var _this = this;
         $.ajax({
@@ -173,10 +170,10 @@ define([
       },
 
       componentDidMount: function() {
-        this.refreshAllPrs();
+        this.refreshPrs();
         this.refreshUserInfo();
         // Refresh every 5 minutes:
-        this.refreshInterval = window.setInterval(this.refreshAllPrs, 1000 * 60 * 5);
+        this.refreshInterval = window.setInterval(this.refreshPrs, 1000 * 60 * 5);
       },
 
       componentWillUnmount: function() {
@@ -193,7 +190,7 @@ define([
         );
 
         var countStalePrsBadge = (
-          React.createElement("span", {className: "badge"},
+          React.createElement("span", {className: "badge"}, 
             this.state.stalePrs.length
           )
         );
@@ -231,13 +228,13 @@ define([
                     React.createElement("a", {href: "/open-prs"}, 
                       "Open PRs ", countPrsBadge
                     )
-                  ),
-                  React.createElement("li", {className: (pathname === '/stale-prs') ? "active" : ""},
-                    React.createElement("a", {href: "/stale-prs"},
+                  ), 
+                  React.createElement("li", {className: (pathname === '/stale-prs') ? "active" : ""}, 
+                    React.createElement("a", {href: "/stale-prs"}, 
                       "Stale PRs ", countStalePrsBadge
                     )
-                  ),
-                  React.createElement("li", {className: pathname.indexOf('/users') === 0 ? "active" : ""},
+                  ), 
+                  React.createElement("li", {className: pathname.indexOf('/users') === 0 ? "active" : ""}, 
                     React.createElement("a", {href: "/users"}, 
                     "Users"
                     )
@@ -246,7 +243,7 @@ define([
                 ), 
                 React.createElement("div", {className: "pull-right"}, 
                   githubUser, 
-                  React.createElement(RefreshButton, {onClick: this.refreshAllPrs, enabled: !this.state.refreshInProgress}),
+                  React.createElement(RefreshButton, {onClick: this.refreshPrs, enabled: !this.state.refreshInProgress}), 
                   loginButton
                 )
               )

--- a/static/js/views/Dashboard.js
+++ b/static/js/views/Dashboard.js
@@ -66,7 +66,7 @@ define([
       },
 
       _checkTabAvailability: function(prsByComponent) {
-        var hash = window.location.hash.split('#');
+        var hash = window.location.hash.split(/#|&/);
         var anchor = hash.pop();
 
         for (var component in prsByComponent) {

--- a/static/js/views/StaleDashboard.js
+++ b/static/js/views/StaleDashboard.js
@@ -1,0 +1,135 @@
+define([
+    'react',
+    'jquery',
+    'underscore',
+    'views/Dashboard',
+    'mixins/UrlMixin'
+  ],
+  function(React, $, _, Dashboard, UrlMixin) {
+    "use strict";
+
+    var StaleNavigationItem = React.createClass({displayName: "StaleNavigationItem",
+      mixins: [UrlMixin],
+      onClick: function(event) {
+        var hash = window.location.hash.split(/#|&/);
+        var curComponent = hash.pop();
+        var component = curComponent ? curComponent : "all";
+        this.pushAnchor(component, this.props.opt);
+      },
+
+      render: function() {
+        var opt = this.props.opt;
+        return (
+          React.createElement("li", {className: opt === this.props.activeOpt ? "subnav-active" : ""}, 
+            React.createElement("a", {onClick: this.onClick}, 
+              opt + " (" + this.props.prsByOpt[opt].length + ")"
+            )
+          )
+        );
+      }
+    });
+
+    var StaleDashboard = React.createClass({displayName: "StaleDashboard",
+      mixins: [UrlMixin],
+      getInitialState: function() {
+        return {prs: [], stalePrs: [], staleOpt: '', prsByOpt: {}};
+      },
+
+      componentDidMount: function() {
+        if (this.props.prs.length > 0) {
+          this._prepareData(this.props.prs);
+        }
+      },
+
+      componentWillReceiveProps: function(nextProps) {
+        this._prepareData(nextProps.prs);
+      },
+
+      componentDidUpdate: function(prevProps, prevState) {
+        var newStaleOpt = this.state.staleOpt;
+        if (prevState.staleOpt !== newStaleOpt || prevState.stalePrs !== this.state.stalePrs) {
+          this.setState({
+            staleOpt: newStaleOpt,
+            stalePrs: this.state.prsByOpt[newStaleOpt] || []
+          });
+        }
+      },
+
+      _prepareData: function(prs) {
+        var prsByOpt = {}, allOpt = "All", hangOpt = "Hanging", abandOpt = "Abandoned";
+        prsByOpt[allOpt] = [];
+        prsByOpt[hangOpt] = [];
+        prsByOpt[abandOpt] = [];
+
+        for (var i = 0; i < prs.length; i++) {
+          var pr = prs[i];
+          if (pr.commenters.length === 0 || pr.commenters[0].username === pr.user) {
+            prsByOpt[hangOpt].push(pr);
+          } else {
+            prsByOpt[abandOpt].push(pr);
+          }
+          prsByOpt[allOpt].push(pr);
+        }
+
+        var curOpt = this._checkOptAvailability(prsByOpt);
+
+        this.setState({
+          stalePrs: prs,
+          staleOpt: curOpt ? curOpt : allOpt,
+          prsByOpt: prsByOpt
+        });
+      },
+
+      _checkOptAvailability: function(prsByOpt) {
+        var hash = window.location.hash.split(/#|&/);
+        hash.pop(); // pop component off
+        var anchor = hash.pop();
+
+        for (var opt in prsByOpt) {
+          if (this.getAnchor(opt) === anchor) {
+            return opt;
+          }
+        }
+      },
+
+      render: function() {
+        var navigationItems = [],
+          prsByOpt = this.state.prsByOpt;
+
+        for (var opt in prsByOpt) {
+          navigationItems.push(
+            React.createElement(StaleNavigationItem, {
+              prsByOpt: prsByOpt, 
+              activeOpt: this.state.staleOpt, 
+              opt: opt}));
+        }
+
+        var staleNavigation = (
+          React.createElement("nav", {className: "sub-nav navbar navbar-default", role: "navigation"}, 
+            React.createElement("div", {className: "container-fluid"}, 
+              React.createElement("ul", {className: "nav navbar-nav"}, 
+                navigationItems
+              )
+            )
+          )
+        );
+
+        var dashboard = (
+          React.createElement(Dashboard, {
+            prs: this.state.stalePrs, 
+            showJenkinsButtons: this.props.showJenkinsButtons})
+        );
+
+        return (
+          React.createElement("div", {className: "stale-dash"}, 
+            staleNavigation, 
+            dashboard
+          )
+        );
+      }
+    });
+
+
+    return StaleDashboard;
+  }
+);

--- a/static/js/views/SubNavigation.js
+++ b/static/js/views/SubNavigation.js
@@ -9,7 +9,12 @@ define([
       mixins: [UrlMixin],
       onClick: function(event) {
         var component = this.props.component;
-        this.pushAnchor(component);
+        var hash = window.location.hash.split(/#|&/);
+        if (hash.length === 3) {
+          this.pushAnchor(component, hash[1]);
+        } else {
+          this.pushAnchor(component);
+        }
       },
 
       render: function() {

--- a/static/jsx/mixins/UrlMixin.jsx
+++ b/static/jsx/mixins/UrlMixin.jsx
@@ -10,8 +10,11 @@ define([
         return component.replace(/ /g,'').toLowerCase();
       },
 
-      pushAnchor: function(component) {
+      pushAnchor: function(component, staleOpt) {
         var anchor = this.getAnchor(component);
+        if (typeof staleOpt !== 'undefined') {
+          anchor = this.getAnchor(staleOpt) + '&' + anchor;
+        }
         window.location.hash = anchor;
       }
     };

--- a/static/jsx/views/AppManager.jsx
+++ b/static/jsx/views/AppManager.jsx
@@ -4,10 +4,11 @@ define([
     'jquery',
     'underscore',
     'views/Dashboard',
+    'views/StaleDashboard',
     'views/UsersPage',
     'views/UserDashboard'
   ],
-  function(React, Router, $, _, Dashboard, UsersPage, UserDashboard) {
+  function(React, Router, $, _, Dashboard, StaleDashboard, UsersPage, UserDashboard) {
     "use strict";
 
     var RouterMixin = Router.RouterMixin;
@@ -75,6 +76,7 @@ define([
       routes: {
         '/': 'openPrs',
         '/open-prs': 'openPrs',
+        '/stale-prs': 'staleOpenPrs',
         '/users/': 'users',
         '/users/:username*': 'userDashboard'
       },
@@ -95,6 +97,14 @@ define([
           );
       },
 
+      staleOpenPrs: function() {
+        return (
+          <StaleDashboard
+            prs={this.state.stalePrs}
+            showJenkinsButtons={this.userCanUseJenkins()}/>
+          );
+      },
+
       users: function() {
         return (<UsersPage prs={this.state.prs}/>);
       },
@@ -108,7 +118,7 @@ define([
       },
 
       getInitialState: function() {
-        return {prs: [], user: null, refreshInProgress: false};
+        return {prs: [], stalePrs: [], user: null, refreshInProgress: false};
       },
 
       refreshPrs: function() {
@@ -121,6 +131,24 @@ define([
           success: function(prs) {
             _this.setState({prs: prs, refreshInProgress: false});
             console.log("Done refreshing pull requests; prs.length=" + prs.length);
+          },
+          error: function() {
+            _this.setState({refreshInProgress: false});
+          }
+        });
+        this.refreshStalePrs();
+      },
+
+      refreshStalePrs: function() {
+        var _this = this;
+        this.setState({refreshInProgress: true});
+        console.log("Refreshing stale pull requests");
+        $.ajax({
+          url: '/search-stale-prs',
+          dataType: 'json',
+          success: function(stalePrs) {
+            _this.setState({stalePrs: stalePrs, refreshInProgress: false});
+            console.log("Done refreshing stale pull requests; stalePrs.length=" + stalePrs.length);
           },
           error: function() {
             _this.setState({refreshInProgress: false});
@@ -161,6 +189,12 @@ define([
           </span>
         );
 
+        var countStalePrsBadge = (
+          <span className="badge">
+            {this.state.stalePrs.length}
+          </span>
+        );
+
         var adminTab = (
           <li className={pathname === '/admin' ? "active" : ""}>
             <a href="/admin">
@@ -193,6 +227,11 @@ define([
                   <li className={(pathname === '/open-prs' || pathname === '/') ? "active" : ""}>
                     <a href="/open-prs">
                       Open PRs {countPrsBadge}
+                    </a>
+                  </li>
+                  <li className={(pathname === '/stale-prs') ? "active" : ""}>
+                    <a href="/stale-prs">
+                      Stale PRs {countStalePrsBadge}
                     </a>
                   </li>
                   <li className={pathname.indexOf('/users') === 0 ? "active" : ""}>

--- a/static/jsx/views/Dashboard.jsx
+++ b/static/jsx/views/Dashboard.jsx
@@ -66,7 +66,7 @@ define([
       },
 
       _checkTabAvailability: function(prsByComponent) {
-        var hash = window.location.hash.split('#');
+        var hash = window.location.hash.split(/#|&/);
         var anchor = hash.pop();
 
         for (var component in prsByComponent) {

--- a/static/jsx/views/StaleDashboard.jsx
+++ b/static/jsx/views/StaleDashboard.jsx
@@ -1,0 +1,135 @@
+define([
+    'react',
+    'jquery',
+    'underscore',
+    'views/Dashboard',
+    'mixins/UrlMixin'
+  ],
+  function(React, $, _, Dashboard, UrlMixin) {
+    "use strict";
+
+    var StaleNavigationItem = React.createClass({
+      mixins: [UrlMixin],
+      onClick: function(event) {
+        var hash = window.location.hash.split(/#|&/);
+        var curComponent = hash.pop();
+        var component = curComponent ? curComponent : "all";
+        this.pushAnchor(component, this.props.opt);
+      },
+
+      render: function() {
+        var opt = this.props.opt;
+        return (
+          <li className={opt === this.props.activeOpt ? "subnav-active" : ""}>
+            <a onClick={this.onClick}>
+              {opt + " (" + this.props.prsByOpt[opt].length + ")"}
+            </a>
+          </li>
+        );
+      }
+    });
+
+    var StaleDashboard = React.createClass({
+      mixins: [UrlMixin],
+      getInitialState: function() {
+        return {prs: [], stalePrs: [], staleOpt: '', prsByOpt: {}};
+      },
+
+      componentDidMount: function() {
+        if (this.props.prs.length > 0) {
+          this._prepareData(this.props.prs);
+        }
+      },
+
+      componentWillReceiveProps: function(nextProps) {
+        this._prepareData(nextProps.prs);
+      },
+
+      componentDidUpdate: function(prevProps, prevState) {
+        var newStaleOpt = this.state.staleOpt;
+        if (prevState.staleOpt !== newStaleOpt || prevState.stalePrs !== this.state.stalePrs) {
+          this.setState({
+            staleOpt: newStaleOpt,
+            stalePrs: this.state.prsByOpt[newStaleOpt] || []
+          });
+        }
+      },
+
+      _prepareData: function(prs) {
+        var prsByOpt = {}, allOpt = "All", hangOpt = "Hanging", abandOpt = "Abandoned";
+        prsByOpt[allOpt] = [];
+        prsByOpt[hangOpt] = [];
+        prsByOpt[abandOpt] = [];
+
+        for (var i = 0; i < prs.length; i++) {
+          var pr = prs[i];
+          if (pr.commenters.length === 0 || pr.commenters[0].username === pr.user) {
+            prsByOpt[hangOpt].push(pr);
+          } else {
+            prsByOpt[abandOpt].push(pr);
+          }
+          prsByOpt[allOpt].push(pr);
+        }
+
+        var curOpt = this._checkOptAvailability(prsByOpt);
+
+        this.setState({
+          stalePrs: prs,
+          staleOpt: curOpt ? curOpt : allOpt,
+          prsByOpt: prsByOpt
+        });
+      },
+
+      _checkOptAvailability: function(prsByOpt) {
+        var hash = window.location.hash.split(/#|&/);
+        hash.pop(); // pop component off
+        var anchor = hash.pop();
+
+        for (var opt in prsByOpt) {
+          if (this.getAnchor(opt) === anchor) {
+            return opt;
+          }
+        }
+      },
+
+      render: function() {
+        var navigationItems = [],
+          prsByOpt = this.state.prsByOpt;
+
+        for (var opt in prsByOpt) {
+          navigationItems.push(
+            <StaleNavigationItem
+              prsByOpt={prsByOpt}
+              activeOpt={this.state.staleOpt}
+              opt={opt}/>);
+        }
+
+        var staleNavigation = (
+          <nav className="sub-nav navbar navbar-default" role="navigation">
+            <div className="container-fluid">
+              <ul className="nav navbar-nav">
+                {navigationItems}
+              </ul>
+            </div>
+          </nav>
+        );
+
+        var dashboard = (
+          <Dashboard
+            prs={this.state.stalePrs}
+            showJenkinsButtons={this.props.showJenkinsButtons}/>
+        );
+
+        return (
+          <div className="stale-dash">
+            {staleNavigation}
+            {dashboard}
+          </div>
+        );
+      }
+    });
+
+
+    return StaleDashboard;
+  }
+);

--- a/static/jsx/views/SubNavigation.jsx
+++ b/static/jsx/views/SubNavigation.jsx
@@ -9,7 +9,12 @@ define([
       mixins: [UrlMixin],
       onClick: function(event) {
         var component = this.props.component;
-        this.pushAnchor(component);
+        var hash = window.location.hash.split(/#|&/);
+        if (hash.length === 3) {
+          this.pushAnchor(component, hash[1]);
+        } else {
+          this.pushAnchor(component);
+        }
       },
 
       render: function() {


### PR DESCRIPTION
Fixes #1 

I added a new Stale PRs dash and sorting options for all, hanging, or abandoned PRs. These new dashes are still sortable by component as have all the features of the original dash.

Known behavioral oddity: When a component tab (such as Mesos) is selected and you you switch to a status tab (like Hanging or Abandoned) where there are no PRs in that component it will show the All components tab, but if you switch back to a status tab where the component exists it will switch back to it (instead of staying on all). This is caused by the default behavior of showing the All tab when the hash in the url matches an nonexistent tab.

Open Question: Is the UI ok? It works and doesn't look too bad, but the two sorting tab rows with the same color right on top of each other feels a bit off. What are some suggestions to fix this?

Screenshots:
![all-all](https://cloud.githubusercontent.com/assets/13952758/14869804/d11177f4-0c8a-11e6-9588-3c50ffcfb97d.png)
![all-build](https://cloud.githubusercontent.com/assets/13952758/14869817/d990cdee-0c8a-11e6-86b2-28fef50b284d.png)
![hang-all](https://cloud.githubusercontent.com/assets/13952758/14869823/dd0372f6-0c8a-11e6-86e2-d91f54db0113.png)
![hang-build](https://cloud.githubusercontent.com/assets/13952758/14869827/de5087ac-0c8a-11e6-8a75-40d32ed58b99.png)
![aband-all](https://cloud.githubusercontent.com/assets/13952758/14869829/df9fa8fe-0c8a-11e6-9cf4-e1d8b454d3c0.png)
![aband-build](https://cloud.githubusercontent.com/assets/13952758/14869831/e0d5832e-0c8a-11e6-905e-09bab98d11e7.png)
