### PR TITLE
Added daily cron job to set deleted prs state not open

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -5,3 +5,6 @@ cron:
 - description: update JIRA issues
   url: /tasks/update-jira-issues
   schedule: every 5 minutes
+- description: clean up deleted Github pull requests
+  url: /tasks/github/clean-prs
+  schedule: every 24 hours

--- a/cron.yaml
+++ b/cron.yaml
@@ -5,6 +5,6 @@ cron:
 - description: update JIRA issues
   url: /tasks/update-jira-issues
   schedule: every 5 minutes
-- description: clean up deleted Github pull requests
-  url: /tasks/github/clean-prs
+- description: update all open Github pull requests
+  url: /tasks/github/refresh-all-prs
   schedule: every 24 hours

--- a/sparkprs/github_api.py
+++ b/sparkprs/github_api.py
@@ -1,5 +1,6 @@
 from google.appengine.api import urlfetch
 from link_header import parse as parse_link_header
+from urllib2 import HTTPError
 import logging
 import json
 
@@ -35,6 +36,8 @@ def raw_github_request(url, oauth_token=None, etag=None, method="GET"):
         return response
     elif response.status_code == 200:
         return response
+    elif response.status_code == 404:
+        raise HTTPError(url, response.status_code, "404 Not Found", response.headers, None)
     else:
         raise Exception("Unexpected status code: %i\n%s" % (response.status_code, response.content))
 

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -6,10 +6,6 @@ import logging
 import re
 from sparkprs import app
 from sparkprs.utils import parse_pr_title, is_jenkins_command, compute_last_jenkins_outcome
-from sparkprs.github_api import raw_github_request, get_pulls_base
-
-
-oauth_token = app.config['GITHUB_OAUTH_KEY']
 
 
 class KVS(ndb.Model):
@@ -192,18 +188,6 @@ class Issue(ndb.Model):
                     (user_dict.get('asked_to_close') or
                         Issue.ASKED_TO_CLOSE_REGEX.search(comment['body']) is not None)
         return sorted(res.items(), key=lambda x: x[1]['date'], reverse=True)
-
-    def refresh(self):
-        try:
-            raw_github_request(get_pulls_base() + '/%i' % self.number,
-                               oauth_token=oauth_token, etag=self.etag)
-        except Exception as e:
-            if "404" in str(e):
-                logging.debug("Deleted pull request found: %i" % self.number)
-                self.state = "deleted"
-                self.put()
-            else:
-                raise
 
     @classmethod
     def get_or_create(cls, number):

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -6,6 +6,10 @@ import logging
 import re
 from sparkprs import app
 from sparkprs.utils import parse_pr_title, is_jenkins_command, compute_last_jenkins_outcome
+from sparkprs.github_api import raw_github_request, get_pulls_base
+
+
+oauth_token = app.config['GITHUB_OAUTH_KEY']
 
 
 class KVS(ndb.Model):
@@ -188,6 +192,18 @@ class Issue(ndb.Model):
                     (user_dict.get('asked_to_close') or
                         Issue.ASKED_TO_CLOSE_REGEX.search(comment['body']) is not None)
         return sorted(res.items(), key=lambda x: x[1]['date'], reverse=True)
+
+    def refresh(self):
+        try:
+            raw_github_request(get_pulls_base() + '/%i' % self.number,
+                               oauth_token=oauth_token, etag=self.etag)
+        except Exception as e:
+            if "404" in str(e):
+                logging.debug("Deleted pull request found: %i" % self.number)
+                self.state = "deleted"
+                self.put()
+            else:
+                raise
 
     @classmethod
     def get_or_create(cls, number):


### PR DESCRIPTION
A fix for #72 
I've added a daily cron job to run a new clean-prs function call. The function checks github for every pr listed as open in the datastore and if it returns a 404 it changes the pr's state to "deleted" so it won't show up in the dash. Currently there's only one pr stuck in this state, but this will protect it from happening again.