### PR TITLE
Highlight links to closed JIRA issues in red

### DIFF
--- a/sparkprs/controllers/prs.py
+++ b/sparkprs/controllers/prs.py
@@ -60,6 +60,7 @@ def search_prs(prs):
             # Use the first JIRA's information to populate the "Priority" and "Issue Type" columns:
             jiras = pr.parsed_title["jiras"]
             if jiras:
+                d['closed_jiras'] = []
                 first_jira = JIRAIssue.get_by_id("%s-%i" % (app.config['JIRA_PROJECT'], jiras[0]))
                 if first_jira:
                     d['jira_priority_name'] = first_jira.priority_name
@@ -74,6 +75,8 @@ def search_prs(prs):
                     jira = JIRAIssue.get_by_id("%s-%i" % (app.config['JIRA_PROJECT'], jira_number))
                     if jira:
                         target_versions.update(jira.target_versions)
+                        if jira.is_closed:
+                            d['closed_jiras'].append(jira_number)
                 if target_versions:
                     d['jira_target_versions'] = natsorted(target_versions)
             json_dicts.append(d)

--- a/sparkprs/models.py
+++ b/sparkprs/models.py
@@ -215,8 +215,8 @@ class JIRAIssue(ndb.Model):
     issue_json = ndb.JsonProperty(compressed=True)
 
     @property
-    def status_name(self):
-        return self.issue_json["fields"]['status']['statusCategory']['name']
+    def is_closed(self):
+        return self.issue_json['fields']['status']['statusCategory']['name'] == "Complete"
 
     @property
     def status_icon_url(self):

--- a/static/js/views/PRTableView.js
+++ b/static/js/views/PRTableView.js
@@ -24,8 +24,12 @@ define([
     var JIRALink = React.createClass({displayName: "JIRALink",
       render: function() {
         var link = "http://issues.apache.org/jira/browse/SPARK-" + this.props.number;
+        var className = "jira-link";
+        if (this.props.isClosed) {
+          className += " label label-pill label-danger";
+        }
         return (
-          React.createElement("a", {className: "jira-link", href: link, target: "_blank"}, 
+          React.createElement("a", {className: className, href: link, target: "_blank"}, 
             this.props.number
           )
         );
@@ -116,7 +120,8 @@ define([
       render: function() {
         var pr = this.props.pr;
         var jiraLinkRows = _.map(pr.parsed_title.jiras, function(number) {
-          return (React.createElement("li", null, React.createElement(JIRALink, {key: number, number: number})));
+          var isClosed = $.inArray(number, pr.closed_jiras) !== -1;
+          return (React.createElement("li", null, React.createElement(JIRALink, {key: number, number: number, isClosed: isClosed})));
         });
         var jiraLinks = React.createElement("ul", {className: "jira-links-list"}, jiraLinkRows);
 

--- a/static/jsx/views/PRTableView.jsx
+++ b/static/jsx/views/PRTableView.jsx
@@ -24,8 +24,12 @@ define([
     var JIRALink = React.createClass({
       render: function() {
         var link = "http://issues.apache.org/jira/browse/SPARK-" + this.props.number;
+        var className = "jira-link";
+        if (this.props.isClosed) {
+          className += " label label-pill label-danger";
+        }
         return (
-          <a className="jira-link" href={link} target="_blank">
+          <a className={className} href={link} target="_blank">
             {this.props.number}
           </a>
         );
@@ -116,7 +120,8 @@ define([
       render: function() {
         var pr = this.props.pr;
         var jiraLinkRows = _.map(pr.parsed_title.jiras, function(number) {
-          return (<li><JIRALink key={number} number={number}/></li>);
+          var isClosed = $.inArray(number, pr.closed_jiras) !== -1;
+          return (<li><JIRALink key={number} number={number} isClosed={isClosed}/></li>);
         });
         var jiraLinks = <ul className="jira-links-list">{jiraLinkRows}</ul>;
 


### PR DESCRIPTION
This patch adds red highlighting to JIRA links when the linked JIRA is closed / resolved:

![image](https://cloud.githubusercontent.com/assets/50748/18331122/69c6e35a-7511-11e6-8d31-d1254b3f5550.png)

This makes it easy to spot old PRs which have been subsumed by later PRs.