### PR TITLE
Fixed word wrap so table is not wider than page

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -88,4 +88,6 @@ span[data-toggle="popover"]:focus {
 
 .pr-title {
     word-break: break-word;
+    display: inline-block;
+    min-width: 300px;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -85,3 +85,7 @@ span[data-toggle="popover"]:focus {
   list-style: none;
   padding-left:0;
 }
+
+.pr-title {
+    word-break: break-word;
+}

--- a/static/js/views/PRTableView.js
+++ b/static/js/views/PRTableView.js
@@ -216,7 +216,7 @@ define([
               targetVersions
             ), 
             React.createElement("td", null, 
-              React.createElement("a", {href: pullLink, target: "_blank"}, 
+              React.createElement("a", {href: pullLink, target: "_blank", className: "pr-title"}, 
                 pr.parsed_title.metadata + pr.parsed_title.title
               )
             ), 

--- a/static/jsx/views/PRTableView.jsx
+++ b/static/jsx/views/PRTableView.jsx
@@ -216,7 +216,7 @@ define([
               {targetVersions}
             </td>
             <td>
-              <a href={pullLink} target="_blank">
+              <a href={pullLink} target="_blank" className="pr-title">
                 {pr.parsed_title.metadata + pr.parsed_title.title}
               </a>
             </td>


### PR DESCRIPTION
Updated the css so pr titles will wrap mid-word if a word is so long it would make the table wider than the page. It only wraps on long words and only the title column is affected (long usernames aren't wrapped).

Tested on Latest Safari, Chrome and FirefoxESR

Before and after screenshots of the pr title that was causing the issue currently:
<img width="1427" alt="screen shot 2016-11-04 at 2 31 24 pm" src="https://cloud.githubusercontent.com/assets/13952758/20023363/c2dfbe9a-a29c-11e6-9b5f-a00a7e7cc097.png">
<img width="1426" alt="screen shot 2016-11-04 at 2 30 09 pm" src="https://cloud.githubusercontent.com/assets/13952758/20023366/c5e6ae1e-a29c-11e6-94ca-36f3b0634d47.png">
